### PR TITLE
Check revoked certificates with OCSP (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cert # => #<OpenSSL::X509::Certificate...>
 
 SSLTester performs a HEAD request using ruby `net/https` library and verifies the SSL status. It also hooks into the validation process to intercept the raw certificate for you.
 
-After that it queries the [OCSP](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) endpoint to verify if the certificate has been revoked.
+After that it queries the [OCSP](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) endpoint to verify if the certificate has been revoked. OCSP responses are cached in memory so be careful if you try to validate millions of certificates.
 
 ### What kind of errors will SSLTest detect
 
@@ -79,11 +79,11 @@ Pretty much the same errors `curl` will:
 - Untrusted root (if your system is up-to-date)
 - And more...
 
-But also revoked certs like most browsers (not handled by `curl`)
+But also *revoked certs* like most browsers (not handled by `curl`)
 
 ## Changelog
 
-1.3.0 - 2020-04-25: Added revoked cert detection using OCSP (#3)
+* 1.3.0 - 2020-04-25: Added revoked cert detection using OCSP (#3)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Pretty much the same errors `curl` will:
 - Untrusted root (if your system is up-to-date)
 - And more...
 
-But also *revoked certs* like most browsers (not handled by `curl`)
+But also **revoked certs** like most browsers (not handled by `curl`)
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,8 @@ Pretty much the same errors `curl` will:
 - Self signed certificates
 - Valid certs used with incorect hostname
 - Untrusted root (if your system is up-to-date)
+- Revoked certs
 - And more...
-
-### GOTCHA: errors SSLTest will NOT detect
-
-There is a spefic kind or error this code will **NOT** detect: *revoked certificates*. This is much more complex to handle because it needs an up to date database of revoked certs to check with. This is implemented in most modern browsers but the results vary greatly (chrome ignores this for example).
-
-Here is an example of website with a revoked certificate: https://revoked.badssl.com/
-
-Any contribution to add this feature is greatly appreciated :)
 
 ## Contributing
 

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -91,15 +91,18 @@ module SSLTest
     return OCSP_SOFT_FAIL_RETURN unless http_response
 
     response = OpenSSL::OCSP::Response.new http_response.body
+    # https://ruby-doc.org/stdlib-2.6.3/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
+    return OCSP_SOFT_FAIL_RETURN unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL
     basic_response = response.basic
 
     # Check the response signature
     store = OpenSSL::X509::Store.new
     store.set_default_paths
-    return OCSP_SOFT_FAIL_RETURN unless basic_response.verify([], store)
+    # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-verify
+    return OCSP_SOFT_FAIL_RETURN unless basic_response.verify(chain, store)
 
     # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/Request.html#method-i-check_nonce
-    return OCSP_SOFT_FAIL_RETURN unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL && request.check_nonce(basic_response) != 0
+    return OCSP_SOFT_FAIL_RETURN unless request.check_nonce(basic_response) != 0
 
     # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-status
     response_certificate_id, status, reason, revocation_time, _this_update, _next_update, _extensions = basic_response.status.first

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -67,6 +67,7 @@ module SSLTest
 
   # https://docs.ruby-lang.org/en/2.2.0/OpenSSL/OCSP.html
   # https://stackoverflow.com/questions/16244084/how-to-programmatically-check-if-a-certificate-has-been-revoked#answer-16257470
+  # Returns an array with [ocsp_check_failed, certificate_revoked, error_reason, revocation_date]
   def self.test_ocsp_revocation cert, chain, open_timeout: 5, read_timeout: 5, redirection_limit: 5
     issuer = chain.last
 
@@ -109,7 +110,7 @@ module SSLTest
 
     return OCSP_SOFT_FAIL_RETURN unless response_certificate_id.serial == certificate_id.serial
     return [false, true, revocation_reason_to_string(reason), revocation_time] if status == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
-    OCSP_SOFT_FAIL_RETURN
+    [false, false, nil, nil]
   rescue => e
     return [true, nil, e.message, nil]
   end

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -92,6 +92,11 @@ module SSLTest
     response = OpenSSL::OCSP::Response.new http_response.body
     basic_response = response.basic
 
+    # Check the response signature
+    store = OpenSSL::X509::Store.new
+    store.set_default_paths
+    return OCSP_FAIL_RETURN unless basic_response.verify([], store)
+
     # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/Request.html#method-i-check_nonce
     return OCSP_FAIL_RETURN unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL && request.check_nonce(basic_response) != 0
 

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -4,7 +4,7 @@ require "openssl"
 require "uri"
 
 module SSLTest
-  VERSION = "1.2.0".freeze
+  VERSION = "1.3.0".freeze
   OCSP_FAIL_RETURN = [false, nil, nil].freeze
 
   def self.test url, open_timeout: 5, read_timeout: 5, redirection_limit: 5

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -26,7 +26,7 @@ module SSLTest
     begin
       http.start { }
       failed, revoked, message, revocation_date = test_ocsp_revocation(cert, chain, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
-      return [nil, "OCSP test failed: #{message}"] if failed
+      return [nil, "OCSP test failed: #{message}", cert] if failed
       return [false, "SSL certificate revoked: #{message} (revocation date: #{revocation_date})", cert] if revoked
       return [true, "OCSP test couldn't be performed: #{message}", cert] if message
       return [true, nil, cert]

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -45,26 +45,6 @@ module SSLTest
     end
   end
 
-  def self.cert_field_to_hash field
-    field.to_a.each.with_object({}) do |v, h|
-      v = v.to_a
-      h[v[0]] = v[1].encode('UTF-8', undef: :replace, invalid: :replace)
-    end
-  end
-
-  def self.cert_domains cert
-    (Array(cert_field_to_hash(cert.subject)['CN']) +
-      cert_field_to_hash(cert.extensions)['subjectAltName'].split(/\s*,\s*/))
-      .compact
-      .map {|s| s.gsub(/^DNS:/, '') }
-      .uniq
-  end
-
-  def self.matching_domains domains, hostname
-    domains.map {|s| Regexp.new("\A#{Regexp.escape(s).gsub('\*', '[^.]+')}\z") }
-      .select {|domain| domain.match?(hostname) }
-  end
-
   # https://docs.ruby-lang.org/en/2.2.0/OpenSSL/OCSP.html
   # https://stackoverflow.com/questions/16244084/how-to-programmatically-check-if-a-certificate-has-been-revoked#answer-16257470
   # Returns an array with [ocsp_check_failed, certificate_revoked, error_reason, revocation_date]
@@ -129,70 +109,94 @@ module SSLTest
     return [true, nil, e.message, nil]
   end
 
-  def self.follow_ocsp_redirects(uri, data, open_timeout: 5, read_timeout: 5, redirection_limit: 5)
-    return nil if redirection_limit == 0
+  class << self
+    private
 
-    path = uri.path == "" ? "/" : uri.path
-    http = Net::HTTP.new(uri.hostname, uri.port)
-    http.open_timeout = open_timeout
-    http.read_timeout = read_timeout
-
-    http_response = http.post(path, data, "content-type" => "application/ocsp-request")
-    case http_response
-    when Net::HTTPSuccess
-      http_response
-    when Net::HTTPRedirection
-      follow_ocsp_redirects(URI(http_response["location"]), data, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit -1)
-    else
-      nil
+    def cert_field_to_hash field
+      field.to_a.each.with_object({}) do |v, h|
+        v = v.to_a
+        h[v[0]] = v[1].encode('UTF-8', undef: :replace, invalid: :replace)
+      end
     end
-  end
 
-  # https://ruby-doc.org/stdlib-2.6.3/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
-  def self.ocsp_response_status_to_string(response_status)
-    case response_status
-    when OpenSSL::OCSP::RESPONSE_STATUS_INTERNALERROR
-      "Internal error in issuer"
-    when OpenSSL::OCSP::RESPONSE_STATUS_MALFORMEDREQUEST
-      "Illegal confirmation request"
-    when OpenSSL::OCSP::RESPONSE_STATUS_SIGREQUIRED
-      "You must sign the request and resubmit"
-    when OpenSSL::OCSP::RESPONSE_STATUS_TRYLATER
-      "Try again later"
-    when OpenSSL::OCSP::RESPONSE_STATUS_UNAUTHORIZED
-      "Your request is unauthorized"
-    else
-      "Unknown reason"
+    def cert_domains cert
+      (Array(cert_field_to_hash(cert.subject)['CN']) +
+        cert_field_to_hash(cert.extensions)['subjectAltName'].split(/\s*,\s*/))
+        .compact
+        .map {|s| s.gsub(/^DNS:/, '') }
+        .uniq
     end
-  end
 
-  def self.ocsp_soft_fail_return(reason)
-     [false, false, reason, nil].freeze
-  end
+    def matching_domains domains, hostname
+      domains.map {|s| Regexp.new("\A#{Regexp.escape(s).gsub('\*', '[^.]+')}\z") }
+        .select {|domain| domain.match?(hostname) }
+    end
 
-  def self.revocation_reason_to_string(revocation_reason)
-    # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
-    case revocation_reason
-    when OpenSSL::OCSP::REVOKED_STATUS_AFFILIATIONCHANGED
-      "The certificate subject's name or other information changed"
-    when OpenSSL::OCSP::REVOKED_STATUS_CACOMPROMISE
-      "This CA certificate was revoked due to a key compromise"
-    when OpenSSL::OCSP::REVOKED_STATUS_CERTIFICATEHOLD
-      "The certificate is on hold"
-    when OpenSSL::OCSP::REVOKED_STATUS_CESSATIONOFOPERATION
-      "The certificate is no longer needed"
-    when OpenSSL::OCSP::REVOKED_STATUS_KEYCOMPROMISE
-      "The certificate was revoked due to a key compromise"
-    when OpenSSL::OCSP::REVOKED_STATUS_NOSTATUS
-      "The certificate was revoked for an unknown reason"
-    when OpenSSL::OCSP::REVOKED_STATUS_REMOVEFROMCRL
-      "The certificate was previously on hold and should now be removed from the CRL"
-    when OpenSSL::OCSP::REVOKED_STATUS_SUPERSEDED
-      "The certificate was superseded by a new certificate"
-    when OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED
-      "The certificate was revoked for an unspecified reason"
-    else
-      "Unknown reason"
+    def follow_ocsp_redirects(uri, data, open_timeout: 5, read_timeout: 5, redirection_limit: 5)
+      return nil if redirection_limit == 0
+
+      path = uri.path == "" ? "/" : uri.path
+      http = Net::HTTP.new(uri.hostname, uri.port)
+      http.open_timeout = open_timeout
+      http.read_timeout = read_timeout
+
+      http_response = http.post(path, data, "content-type" => "application/ocsp-request")
+      case http_response
+      when Net::HTTPSuccess
+        http_response
+      when Net::HTTPRedirection
+        follow_ocsp_redirects(URI(http_response["location"]), data, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit -1)
+      else
+        nil
+      end
+    end
+
+    # https://ruby-doc.org/stdlib-2.6.3/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
+    def ocsp_response_status_to_string(response_status)
+      case response_status
+      when OpenSSL::OCSP::RESPONSE_STATUS_INTERNALERROR
+        "Internal error in issuer"
+      when OpenSSL::OCSP::RESPONSE_STATUS_MALFORMEDREQUEST
+        "Illegal confirmation request"
+      when OpenSSL::OCSP::RESPONSE_STATUS_SIGREQUIRED
+        "You must sign the request and resubmit"
+      when OpenSSL::OCSP::RESPONSE_STATUS_TRYLATER
+        "Try again later"
+      when OpenSSL::OCSP::RESPONSE_STATUS_UNAUTHORIZED
+        "Your request is unauthorized"
+      else
+        "Unknown reason"
+      end
+    end
+
+    def ocsp_soft_fail_return(reason)
+       [false, false, reason, nil].freeze
+    end
+
+    def revocation_reason_to_string(revocation_reason)
+      # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
+      case revocation_reason
+      when OpenSSL::OCSP::REVOKED_STATUS_AFFILIATIONCHANGED
+        "The certificate subject's name or other information changed"
+      when OpenSSL::OCSP::REVOKED_STATUS_CACOMPROMISE
+        "This CA certificate was revoked due to a key compromise"
+      when OpenSSL::OCSP::REVOKED_STATUS_CERTIFICATEHOLD
+        "The certificate is on hold"
+      when OpenSSL::OCSP::REVOKED_STATUS_CESSATIONOFOPERATION
+        "The certificate is no longer needed"
+      when OpenSSL::OCSP::REVOKED_STATUS_KEYCOMPROMISE
+        "The certificate was revoked due to a key compromise"
+      when OpenSSL::OCSP::REVOKED_STATUS_NOSTATUS
+        "The certificate was revoked for an unknown reason"
+      when OpenSSL::OCSP::REVOKED_STATUS_REMOVEFROMCRL
+        "The certificate was previously on hold and should now be removed from the CRL"
+      when OpenSSL::OCSP::REVOKED_STATUS_SUPERSEDED
+        "The certificate was superseded by a new certificate"
+      when OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED
+        "The certificate was revoked for an unspecified reason"
+      else
+        "Unknown reason"
+      end
     end
   end
 end

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -110,7 +110,7 @@ module SSLTest
     return OCSP_SOFT_FAIL_RETURN unless response_certificate_id.serial == certificate_id.serial
     return [false, true, revocation_reason_to_string(reason), revocation_time] if status == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
     OCSP_SOFT_FAIL_RETURN
-  rescue Exception => e
+  rescue => e
     return [true, nil, e.message, nil]
   end
 

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -69,48 +69,60 @@ module SSLTest
   # https://stackoverflow.com/questions/16244084/how-to-programmatically-check-if-a-certificate-has-been-revoked#answer-16257470
   # Returns an array with [ocsp_check_failed, certificate_revoked, error_reason, revocation_date]
   def self.test_ocsp_revocation cert, chain, open_timeout: 5, read_timeout: 5, redirection_limit: 5
+    @ocsp_response_cache ||= {}
     chain[0..-2].each_with_index do |current_checked_cert, i|
+      # https://tools.ietf.org/html/rfc5280#section-4.1.2.2
+      # The serial number [...] MUST be unique for each certificate issued by a given CA (i.e., the issuer name and serial number identify a unique certificate)
+      unicity_key = [current_checked_cert.issuer.to_s, current_checked_cert.serial.to_s]
+
       issuer = chain[i + 1]
 
       digest = OpenSSL::Digest::SHA1.new
       certificate_id = OpenSSL::OCSP::CertificateId.new(current_checked_cert, issuer, digest)
 
-      request = OpenSSL::OCSP::Request.new
-      request.add_certid certificate_id
-      request.add_nonce
+      if @ocsp_response_cache[unicity_key].nil? || @ocsp_response_cache[unicity_key][:next_update] <= Time.now
+        request = OpenSSL::OCSP::Request.new
+        request.add_certid certificate_id
+        request.add_nonce
 
-      authority_info_access = current_checked_cert.extensions.find do |extension|
-        extension.oid == "authorityInfoAccess"
+        authority_info_access = current_checked_cert.extensions.find do |extension|
+          extension.oid == "authorityInfoAccess"
+        end
+
+        descriptions = authority_info_access.value.split("\n")
+        ocsp = descriptions.find do |description|
+          description.start_with?("OCSP")
+        end
+
+        ocsp_uri = URI(ocsp[/URI:(.*)/, 1])
+        http_response = follow_ocsp_redirects(ocsp_uri, request.to_der, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
+        return ocsp_soft_fail_return("OCSP response request failed") unless http_response
+
+        response = OpenSSL::OCSP::Response.new http_response.body
+        # https://ruby-doc.org/stdlib-2.6.3/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
+        return ocsp_soft_fail_return("OCSP response failed: #{ocsp_response_status_to_string(response.status)}") unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL
+        basic_response = response.basic
+
+        # Check the response signature
+        store = OpenSSL::X509::Store.new
+        store.set_default_paths
+        # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-verify
+        return ocsp_soft_fail_return("OCSP response signature verification failed") unless basic_response.verify(chain, store)
+
+        # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/Request.html#method-i-check_nonce
+        return ocsp_soft_fail_return("OCSP response nonce check failed") unless request.check_nonce(basic_response) != 0
+
+        # https://ruby-doc.org/stdlib-2.3.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-status
+        response_certificate_id, status, reason, revocation_time, this_update, next_update, _extensions = basic_response.status.first
+
+        return ocsp_soft_fail_return("OCSP response serial check failed") unless response_certificate_id.serial == certificate_id.serial
+
+        @ocsp_response_cache[unicity_key] = { status: status, reason: reason, revocation_time: revocation_time, next_update: next_update }
       end
 
-      descriptions = authority_info_access.value.split("\n")
-      ocsp = descriptions.find do |description|
-        description.start_with?("OCSP")
-      end
+      ocsp_response = @ocsp_response_cache[unicity_key]
 
-      ocsp_uri = URI(ocsp[/URI:(.*)/, 1])
-      http_response = follow_ocsp_redirects(ocsp_uri, request.to_der, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
-      return ocsp_soft_fail_return("OCSP response request failed") unless http_response
-
-      response = OpenSSL::OCSP::Response.new http_response.body
-      # https://ruby-doc.org/stdlib-2.6.3/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
-      return ocsp_soft_fail_return("OCSP response failed: #{ocsp_response_status_to_string(response.status)}") unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL
-      basic_response = response.basic
-
-      # Check the response signature
-      store = OpenSSL::X509::Store.new
-      store.set_default_paths
-      # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-verify
-      return ocsp_soft_fail_return("OCSP response signature verification failed") unless basic_response.verify(chain, store)
-
-      # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/Request.html#method-i-check_nonce
-      return ocsp_soft_fail_return("OCSP response nonce check failed") unless request.check_nonce(basic_response) != 0
-
-      # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-status
-      response_certificate_id, status, reason, revocation_time, _this_update, _next_update, _extensions = basic_response.status.first
-
-      return ocsp_soft_fail_return("OCSP response serial check failed") unless response_certificate_id.serial == certificate_id.serial
-      return [false, true, revocation_reason_to_string(reason), revocation_time] if status == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
+      return [false, true, revocation_reason_to_string(ocsp_response[:reason]), ocsp_response[:revocation_time]] if ocsp_response[:status] == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
     end
     [false, false, nil, nil]
   rescue => e

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -1,12 +1,15 @@
+require "net/http"
 require "net/https"
+require "openssl"
+require "uri"
 
 module SSLTest
   VERSION = "1.2.0"
 
-  def self.test url, open_timeout: 5, read_timeout: 5
+  def self.test url, open_timeout: 5, read_timeout: 5, redirection_limit: 5
     uri = URI.parse(url)
     return if uri.scheme != 'https'
-    cert = failed_cert_reason = nil
+    cert = failed_cert_reason = chain = nil
 
     http = Net::HTTP.new(uri.host, uri.port)
     http.open_timeout = open_timeout
@@ -15,12 +18,15 @@ module SSLTest
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.verify_callback = -> (verify_ok, store_context) {
       cert = store_context.current_cert
+      chain = store_context.chain
       failed_cert_reason = [store_context.error, store_context.error_string] if store_context.error != 0
       verify_ok
     }
 
     begin
       http.start { }
+      revoked, revocation_reason, revocation_date = test_ocsp_revocation(cert, chain, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
+      return [false, "SSL certificate revoked: #{revocation_reason} (revocation date: #{revocation_date})", cert] if revoked
       return [true, nil, cert]
     rescue OpenSSL::SSL::SSLError => e
       error = e.message
@@ -55,5 +61,88 @@ module SSLTest
   def self.matching_domains domains, hostname
     domains.map {|s| Regexp.new("\A#{Regexp.escape(s).gsub('\*', '[^.]+')}\z") }
       .select {|domain| domain.match?(hostname) }
+  end
+
+  # https://docs.ruby-lang.org/en/2.2.0/OpenSSL/OCSP.html
+  def self.test_ocsp_revocation cert, chain, open_timeout: 5, read_timeout: 5, redirection_limit: 5
+    issuer = chain.last
+
+    digest = OpenSSL::Digest::SHA1.new
+    certificate_id = OpenSSL::OCSP::CertificateId.new(cert, issuer, digest)
+
+    request = OpenSSL::OCSP::Request.new
+    request.add_certid certificate_id
+    request.add_nonce
+
+    authority_info_access = cert.extensions.find do |extension|
+      extension.oid == "authorityInfoAccess"
+    end
+
+    descriptions = authority_info_access.value.split("\n")
+    ocsp = descriptions.find do |description|
+      description.start_with?("OCSP")
+    end
+
+    ocsp_uri = URI(ocsp[/URI:(.*)/, 1])
+    # "Note that we only handle HTTP requests and don't handle any redirects in this example"
+    http_response = follow_ocsp_redirects(ocsp_uri, request.to_der, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
+    return [false, nil, nil] unless http_response
+
+    response = OpenSSL::OCSP::Response.new http_response.body
+    basic_response = response.basic
+
+    # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/Request.html#method-i-check_nonce
+    return [false, nil, nil] unless response.status == OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL && request.check_nonce(basic_response) != 0
+
+    # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP/BasicResponse.html#method-i-status
+    _response_certificate_id, status, reason, revocation_time, _this_update, _next_update, _extensions = basic_response.status.first
+
+    return [true, revocation_reason_to_string(reason), revocation_time] if status == OpenSSL::OCSP::V_CERTSTATUS_REVOKED
+    [false, nil, nil]
+  end
+
+  def self.follow_ocsp_redirects(uri, data, open_timeout: 5, read_timeout: 5, redirection_limit: 5)
+    return nil if redirection_limit == 0
+
+    path = uri.path == "" ? "/" : uri.path
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.open_timeout = open_timeout
+    http.read_timeout = read_timeout
+
+    http_response = http.post(path, data, "content-type" => "application/ocsp-request")
+    case http_response
+    when Net::HTTPSuccess
+      http_response
+    when Net::HTTPRedirection
+      follow_ocsp_redirects(URI(http_response["location"]), data, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit -1)
+    else
+      nil
+    end
+  end
+
+  def self.revocation_reason_to_string(revocation_reason)
+    # https://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/OCSP.html#constants-list
+    case revocation_reason
+    when OpenSSL::OCSP::REVOKED_STATUS_AFFILIATIONCHANGED
+      "The certificate subject's name or other information changed"
+    when OpenSSL::OCSP::REVOKED_STATUS_CACOMPROMISE
+      "This CA certificate was revoked due to a key compromise"
+    when OpenSSL::OCSP::REVOKED_STATUS_CERTIFICATEHOLD
+      "The certificate is on hold"
+    when OpenSSL::OCSP::REVOKED_STATUS_CESSATIONOFOPERATION
+      "The certificate is no longer needed"
+    when OpenSSL::OCSP::REVOKED_STATUS_KEYCOMPROMISE
+      "The certificate was revoked due to a key compromise"
+    when OpenSSL::OCSP::REVOKED_STATUS_NOSTATUS
+      "The certificate was revoked for an unknown reason"
+    when OpenSSL::OCSP::REVOKED_STATUS_REMOVEFROMCRL
+      "The certificate was previously on hold and should now be removed from the CRL"
+    when OpenSSL::OCSP::REVOKED_STATUS_SUPERSEDED
+      "The certificate was superseded by a new certificate"
+    when OpenSSL::OCSP::REVOKED_STATUS_UNSPECIFIED
+      "The certificate was revoked for an unspecified reason"
+    else
+      "Unknown reason"
+    end
   end
 end

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -73,7 +73,7 @@ module SSLTest
     chain[0..-2].each_with_index do |cert, i|
       # https://tools.ietf.org/html/rfc5280#section-4.1.2.2
       # The serial number [...] MUST be unique for each certificate issued by a given CA (i.e., the issuer name and serial number identify a unique certificate)
-      unicity_key = [cert.issuer.to_s, cert.serial.to_s]
+      unicity_key = "#{cert.issuer}/#{cert.serial}"
 
       if @ocsp_response_cache[unicity_key].nil? || @ocsp_response_cache[unicity_key][:next_update] <= Time.now
         issuer = chain[i + 1]

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -94,5 +94,19 @@ describe SSLTest do
       valid.must_equal true
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end
+
+    it "warns when the OCSP URI is missing" do
+      valid, error, cert = SSLTest.test("https://www.demarches-simplifiees.fr")
+      error.must_equal "OCSP test couldn't be performed: Missing OCSP URI in authorityInfoAccess extension"
+      valid.must_equal true
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
+
+    it "warns when the authorityInfoAccess extension is missing" do
+      valid, error, cert = SSLTest.test("https://www.anonymisation.gov.pf")
+      error.must_equal "OCSP test couldn't be performed: Missing authorityInfoAccess extension"
+      valid.must_equal true
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
   end
 end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -4,13 +4,6 @@ require "minitest/autorun"
 describe SSLTest do
 
   describe '.test' do
-    it "returns no error on valid SNI website" do
-      valid, error, cert = SSLTest.test("https://www.mycs.com")
-      error.must_be_nil
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
-    end
-
     it "returns no error on valid SAN" do
       valid, error, cert = SSLTest.test("https://1000-sans.badssl.com/")
       error.must_be_nil
@@ -55,7 +48,7 @@ describe SSLTest do
 
     it "returns error on invalid host" do
       valid, error, cert = SSLTest.test("https://wrong.host.badssl.com/")
-      error.must_equal 'hostname "wrong.host.badssl.com" does not match the server certificate (*.badssl.com, badssl.com)'
+      error.must_equal 'hostname "wrong.host.badssl.com" does not match the server certificate'
       valid.must_equal false
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end
@@ -83,7 +76,7 @@ describe SSLTest do
 
     it "returns error on revoked cert" do
       valid, error, cert = SSLTest.test("https://revoked.badssl.com/")
-      error.must_equal "SSL certificate revoked: The certificate was revoked for an unknown reason (revocation date: 2016-09-02 21:28:48 UTC)"
+      error.must_equal "SSL certificate revoked: The certificate was revoked for an unknown reason (revocation date: 2019-10-07 20:30:39 UTC)"
       valid.must_equal false
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end
@@ -92,6 +85,13 @@ describe SSLTest do
       valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
       error.must_equal "OCSP test couldn't be performed: OCSP response request failed"
       valid.must_equal true
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
+
+    it "returns a warning on OCSP error" do
+      valid, error, cert = SSLTest.test("https://www.mycs.com")
+      error.must_match /^OCSP test failed: /
+      valid.must_be_nil
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end
   end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -4,6 +4,13 @@ require "minitest/autorun"
 describe SSLTest do
 
   describe '.test' do
+    it "returns no error on valid SNI website" do
+      valid, error, cert = SSLTest.test("https://www.mycs.com")
+      error.must_be_nil
+      valid.must_equal true
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
+
     it "returns no error on valid SAN" do
       valid, error, cert = SSLTest.test("https://1000-sans.badssl.com/")
       error.must_be_nil
@@ -85,13 +92,6 @@ describe SSLTest do
       valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
       error.must_equal "OCSP test couldn't be performed: OCSP response request failed"
       valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
-    end
-
-    it "returns a warning on OCSP error" do
-      valid, error, cert = SSLTest.test("https://www.mycs.com")
-      error.must_match /^OCSP test failed: /
-      valid.must_be_nil
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end
   end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -89,8 +89,8 @@ describe SSLTest do
     end
 
     it "stops following redirection after the limit for the revoked certs check" do
-      valid, error, cert = SSLTest.test("https://revoked.badssl.com/", redirection_limit: 0)
-      error.must_be_nil
+      valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
+      error.must_equal "OCSP test couldn't be performed: OCSP response request failed"
       valid.must_equal true
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -81,12 +81,18 @@ describe SSLTest do
       cert.must_be_nil
     end
 
-    # Not implemented yet
-    # it "returns error on revoked cert" do
-    #   valid, error, cert = SSLTest.test("https://revoked.badssl.com/")
-    #   error.must_equal "error code XX: certificate has been revoked"
-    #   valid.must_equal false
-    #   cert.must_be_instance_of OpenSSL::X509::Certificate
-    # end
+    it "returns error on revoked cert" do
+      valid, error, cert = SSLTest.test("https://revoked.badssl.com/")
+      error.must_equal "SSL certificate revoked: The certificate was revoked for an unknown reason (revocation date: 2016-09-02 21:28:48 UTC)"
+      valid.must_equal false
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
+
+    it "stops following redirection after the limit for the revoked certs check" do
+      valid, error, cert = SSLTest.test("https://revoked.badssl.com/", redirection_limit: 0)
+      error.must_be_nil
+      valid.must_equal true
+      cert.must_be_instance_of OpenSSL::X509::Certificate
+    end
   end
 end


### PR DESCRIPTION
(#2)

This PR adds a test for revoked certificates using [OCSP](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol).
It **does not** use [CRL](https://en.wikipedia.org/wiki/Certificate_revocation_list).

The main inspiration was from the [ruby doc](https://docs.ruby-lang.org/en/2.2.0/OpenSSL/OCSP.html).

I used https://www.digicert.com/digicert-root-certificates.htm to test it on several certificates.