### PR TITLE
Cache OCSP request fail for 5 minutes and display a better error (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ But also **revoked certs** like most browsers (not handled by `curl`)
 
 ## Changelog
 
+* 1.3.1 - 2020-04-25: Improved caching of failed OCSP responses (#5)
 * 1.3.0 - 2020-04-25: Added revoked cert detection using OCSP (#3)
 
 ## Contributing

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -4,7 +4,7 @@ require "openssl"
 require "uri"
 
 module SSLTest
-  VERSION = "1.3.0".freeze
+  VERSION = "1.3.1".freeze
   OCSP_REQUEST_ERROR_CACHE_DURATION = 5 * 60
 
   def self.test url, open_timeout: 5, read_timeout: 5, redirection_limit: 5

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -90,9 +90,9 @@ module SSLTest
         ocsp_uri = URI(ocsp[/URI:(.*)/, 1])
         http_response, ocsp_request_error = follow_ocsp_redirects(ocsp_uri, request.to_der, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
         if http_response.nil?
-          ocsp_request_error_string = ocsp_soft_fail_return("OCSP response request failed (OCSP URI: #{ocsp_uri}, error: #{ocsp_request_error})")
-          @ocsp_request_error_cache[unicity_key] = { error: ocsp_request_error_string, cache_until: Time.now + OCSP_REQUEST_ERROR_CACHE_DURATION }
-          return ocsp_request_error_string
+          ocsp_request_error_return = ocsp_soft_fail_return("OCSP response request failed (OCSP URI: #{ocsp_uri}, error: #{ocsp_request_error})")
+          @ocsp_request_error_cache[unicity_key] = { error: ocsp_request_error_return, cache_until: Time.now + OCSP_REQUEST_ERROR_CACHE_DURATION }
+          return ocsp_request_error_return
         end
 
         response = OpenSSL::OCSP::Response.new http_response.body

--- a/lib/ssl-test.rb
+++ b/lib/ssl-test.rb
@@ -90,7 +90,7 @@ module SSLTest
         ocsp_uri = URI(ocsp[/URI:(.*)/, 1])
         http_response, ocsp_request_error = follow_ocsp_redirects(ocsp_uri, request.to_der, open_timeout: open_timeout, read_timeout: read_timeout, redirection_limit: redirection_limit)
         if http_response.nil?
-          ocsp_request_error_return = ocsp_soft_fail_return("OCSP response request failed (OCSP URI: #{ocsp_uri}, error: #{ocsp_request_error})")
+          ocsp_request_error_return = ocsp_soft_fail_return("request failed (URI: #{ocsp_uri}, error: #{ocsp_request_error})")
           @ocsp_request_error_cache[unicity_key] = { error: ocsp_request_error_return, cache_until: Time.now + OCSP_REQUEST_ERROR_CACHE_DURATION }
           return ocsp_request_error_return
         end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -90,7 +90,7 @@ describe SSLTest do
 
     it "stops following redirection after the limit for the revoked certs check" do
       valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
-      error.must_equal "OCSP test couldn't be performed: OCSP response request failed (OCSP URI: http://ocsp.digicert.com, error: Too many redirections (> 0))"
+      error.must_equal "OCSP test couldn't be performed: request failed (URI: http://ocsp.digicert.com, error: Too many redirections (> 0))"
       valid.must_equal true
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -6,107 +6,107 @@ describe SSLTest do
   describe '.test' do
     it "returns no error on valid SNI website" do
       valid, error, cert = SSLTest.test("https://www.mycs.com")
-      error.must_be_nil
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_be_nil
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns no error on valid SAN" do
       valid, error, cert = SSLTest.test("https://1000-sans.badssl.com/")
-      error.must_be_nil
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_be_nil
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns no error when no CN" do
       valid, error, cert = SSLTest.test("https://no-common-name.badssl.com/")
-      error.must_be_nil
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_be_nil
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "works with websites blocking http requests" do
       valid, error, cert = SSLTest.test("https://obyava.ua")
-      error.must_be_nil
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_be_nil
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns error on self signed certificate" do
       valid, error, cert = SSLTest.test("https://self-signed.badssl.com/")
-      error.must_equal "error code 18: self signed certificate"
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "error code 18: self signed certificate"
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns error on incomplete chain" do
       valid, error, cert = SSLTest.test("https://incomplete-chain.badssl.com/")
-      error.must_equal "error code 20: unable to get local issuer certificate"
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "error code 20: unable to get local issuer certificate"
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns error on untrusted root" do
       valid, error, cert = SSLTest.test("https://untrusted-root.badssl.com/")
-      error.must_equal "error code 20: unable to get local issuer certificate"
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "error code 19: self signed certificate in certificate chain"
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns error on invalid host" do
       valid, error, cert = SSLTest.test("https://wrong.host.badssl.com/")
-      error.must_equal 'hostname "wrong.host.badssl.com" does not match the server certificate'
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      assert error.include?('hostname "wrong.host.badssl.com" does not match the server certificate')
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns error on expired cert" do
       valid, error, cert = SSLTest.test("https://expired.badssl.com/")
-      error.must_equal "error code 10: certificate has expired"
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "error code 10: certificate has expired"
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "returns undetermined state on unhandled error" do
       valid, error, cert = SSLTest.test("https://pijoinlrfgind.com")
-      error.must_equal "SSL certificate test failed: Failed to open TCP connection to pijoinlrfgind.com:443 (getaddrinfo: Name or service not known)"
-      valid.must_be_nil
-      cert.must_be_nil
+      _(error).must_equal "SSL certificate test failed: Failed to open TCP connection to pijoinlrfgind.com:443 (getaddrinfo: Name or service not known)"
+      _(valid).must_be_nil
+      _(cert).must_be_nil
     end
 
     it "stops on timeouts" do
       valid, error, cert = SSLTest.test("https://updown.io", open_timeout: 0)
-      error.must_equal "SSL certificate test failed: Net::OpenTimeout"
-      valid.must_be_nil
-      cert.must_be_nil
+      _(error).must_equal "SSL certificate test failed: Net::OpenTimeout"
+      _(valid).must_be_nil
+      _(cert).must_be_nil
     end
 
     it "returns error on revoked cert" do
       valid, error, cert = SSLTest.test("https://revoked.badssl.com/")
-      error.must_equal "SSL certificate revoked: The certificate was revoked for an unknown reason (revocation date: 2019-10-07 20:30:39 UTC)"
-      valid.must_equal false
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "SSL certificate revoked: The certificate was revoked for an unknown reason (revocation date: 2019-10-07 20:30:39 UTC)"
+      _(valid).must_equal false
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "stops following redirection after the limit for the revoked certs check" do
       valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
-      error.must_equal "OCSP test couldn't be performed: request failed (URI: http://ocsp.digicert.com, error: Too many redirections (> 0))"
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "OCSP test couldn't be performed: Request failed (URI: http://ocsp.digicert.com): Too many redirections (> 0)"
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "warns when the OCSP URI is missing" do
       valid, error, cert = SSLTest.test("https://www.demarches-simplifiees.fr")
-      error.must_equal "OCSP test couldn't be performed: Missing OCSP URI in authorityInfoAccess extension"
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "OCSP test couldn't be performed: Missing OCSP URI in authorityInfoAccess extension"
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
 
     it "warns when the authorityInfoAccess extension is missing" do
       valid, error, cert = SSLTest.test("https://www.anonymisation.gov.pf")
-      error.must_equal "OCSP test couldn't be performed: Missing authorityInfoAccess extension"
-      valid.must_equal true
-      cert.must_be_instance_of OpenSSL::X509::Certificate
+      _(error).must_equal "OCSP test couldn't be performed: Missing authorityInfoAccess extension"
+      _(valid).must_equal true
+      _(cert).must_be_instance_of OpenSSL::X509::Certificate
     end
   end
 end

--- a/test/ssl-test_test.rb
+++ b/test/ssl-test_test.rb
@@ -90,7 +90,7 @@ describe SSLTest do
 
     it "stops following redirection after the limit for the revoked certs check" do
       valid, error, cert = SSLTest.test("https://github.com/", redirection_limit: 0)
-      error.must_equal "OCSP test couldn't be performed: OCSP response request failed"
+      error.must_equal "OCSP test couldn't be performed: OCSP response request failed (OCSP URI: http://ocsp.digicert.com, error: Too many redirections (> 0))"
       valid.must_equal true
       cert.must_be_instance_of OpenSSL::X509::Certificate
     end


### PR DESCRIPTION
(#2)

This PR improves the SSL revocation test.

Sometimes, when we query the OCSP responder, we get a failure. Currently this failure is not cached so we will keep querying the OCSP responder (which might be temporary down).

This PR improves this by caching the error for 5 minutes, so that we won't put more load on the OCSP responder if he's not working properly at the moment.
In addition to that, the error message returned was improved in this situation to explain with it failed and to include the OCSP responder URI.

Here's what the error will look like now:
```ruby
irb(main):001:0> SSLTest.test("https://cloudreports.xyz")
=> [true, "OCSP test couldn't be performed: OCSP response request failed (OCSP URI: http://isrg.trustid.ocsp.identrust.com, error: Wrong response type (Net::HTTPServiceUnavailable))", #<OpenSSL::X509::Certificate: subject=#<OpenSSL::X509::Name CN=cloudreports.xyz>, issuer=#<OpenSSL::X509::Name CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US>, serial=#<OpenSSL::BN:0x0000000006baf620>, not_before="2020-03-10T03:25:33.000Z", not_after="2020-06-08T03:25:33.000Z">]
```